### PR TITLE
changes int to float for health values

### DIFF
--- a/HealthPerLevel.cs
+++ b/HealthPerLevel.cs
@@ -346,12 +346,12 @@ namespace HealthPerLevel_cs
             }
         }
 
-        private double AddHpPerLevel<T, E, G>(double inrement, ICharacter<T, E, G> charType, BodyPartHealth bodyPart, int baseHealth, int increaseHealth)
+        private double AddHpPerLevel<T, E, G>(double inrement, ICharacter<T, E, G> charType, BodyPartHealth bodyPart, float baseHealth, float increaseHealth)
         {
             return baseHealth + (inrement * increaseHealth);
         }
 
-        private double AddHpPerSkillLevel<T, E, G>(ICharacter<T, E, G> charType, double hpSkillv, BodyPartHealth bodyPart, int increasePerHealthSkill)
+        private double AddHpPerSkillLevel<T, E, G>(ICharacter<T, E, G> charType, double hpSkillv, BodyPartHealth bodyPart, float increasePerHealthSkill)
         {
             return charType.health_per_health_skill_level ?
                 Math.Floor(hpSkillv / 100 / charType.health_skill_levels_per_increment) * increasePerHealthSkill :

--- a/HealthPerLevel.cs
+++ b/HealthPerLevel.cs
@@ -295,49 +295,47 @@ namespace HealthPerLevel_cs
 
             double increment = GetIncrement(accLv, charType);
 
-            if (charType.health_per_health_skill_level)
+            switch (bodyPartName)
+            {
+                case "Head":
+                    bodyPart.Health.Maximum = AddHpPerLevel(increment, charType, bodyPart, baseHealth.head_health, increaseHealth.head_health) +
+                        AddHpPerSkillLevel(charType, hpSkillv, bodyPart, increasePerHealthSkill.head_health);
+                    break;
 
-                switch (bodyPartName)
-                {
-                    case "Head":
-                        bodyPart.Health.Maximum = AddHpPerLevel(increment, charType, bodyPart, baseHealth.head_health, increaseHealth.head_health) +
-                            AddHpPerSkillLevel(charType, hpSkillv, bodyPart, increasePerHealthSkill.head_health);
-                        break;
+                case "Chest":
+                    bodyPart.Health.Maximum = AddHpPerLevel(increment, charType, bodyPart, baseHealth.thorax_health, increaseHealth.thorax_health) +
+                        AddHpPerSkillLevel(charType, hpSkillv, bodyPart, increasePerHealthSkill.thorax_health);
+                    break;
 
-                    case "Chest":
-                        bodyPart.Health.Maximum = AddHpPerLevel(increment, charType, bodyPart, baseHealth.thorax_health, increaseHealth.thorax_health) +
-                            AddHpPerSkillLevel(charType, hpSkillv, bodyPart, increasePerHealthSkill.thorax_health);
-                        break;
+                case "Stomach":
+                    bodyPart.Health.Maximum = AddHpPerLevel(increment, charType, bodyPart, baseHealth.stomach_health, increaseHealth.stomach_health) +
+                        AddHpPerSkillLevel(charType, hpSkillv, bodyPart, increasePerHealthSkill.stomach_health);
+                    break;
 
-                    case "Stomach":
-                        bodyPart.Health.Maximum = AddHpPerLevel(increment, charType, bodyPart, baseHealth.stomach_health, increaseHealth.stomach_health) +
-                            AddHpPerSkillLevel(charType, hpSkillv, bodyPart, increasePerHealthSkill.stomach_health);
-                        break;
+                case "LeftArm":
+                    bodyPart.Health.Maximum = AddHpPerLevel(increment, charType, bodyPart, baseHealth.left_arm_health, increaseHealth.left_arm_health) +
+                        AddHpPerSkillLevel(charType, hpSkillv, bodyPart, increasePerHealthSkill.left_arm_health);
+                    break;
 
-                    case "LeftArm":
-                        bodyPart.Health.Maximum = AddHpPerLevel(increment, charType, bodyPart, baseHealth.left_arm_health, increaseHealth.left_arm_health) +
-                            AddHpPerSkillLevel(charType, hpSkillv, bodyPart, increasePerHealthSkill.left_arm_health);
-                        break;
+                case "LeftLeg":
+                    bodyPart.Health.Maximum = AddHpPerLevel(increment, charType, bodyPart, baseHealth.left_leg_health, increaseHealth.left_leg_health) +
+                        AddHpPerSkillLevel(charType, hpSkillv, bodyPart, increasePerHealthSkill.left_leg_health);
+                    break;
 
-                    case "LeftLeg":
-                        bodyPart.Health.Maximum = AddHpPerLevel(increment, charType, bodyPart, baseHealth.left_leg_health, increaseHealth.left_leg_health) +
-                            AddHpPerSkillLevel(charType, hpSkillv, bodyPart, increasePerHealthSkill.left_leg_health);
-                        break;
+                case "RightArm":
+                    bodyPart.Health.Maximum = AddHpPerLevel(increment, charType, bodyPart, baseHealth.right_arm_health, increaseHealth.right_arm_health) +
+                        AddHpPerSkillLevel(charType, hpSkillv, bodyPart, increasePerHealthSkill.right_arm_health);
+                    break;
 
-                    case "RightArm":
-                        bodyPart.Health.Maximum = AddHpPerLevel(increment, charType, bodyPart, baseHealth.right_arm_health, increaseHealth.right_arm_health) +
-                            AddHpPerSkillLevel(charType, hpSkillv, bodyPart, increasePerHealthSkill.right_arm_health);
-                        break;
+                case "RightLeg":
+                    bodyPart.Health.Maximum = AddHpPerLevel(increment, charType, bodyPart, baseHealth.right_leg_health, increaseHealth.right_leg_health) +
+                        AddHpPerSkillLevel(charType, hpSkillv, bodyPart, increasePerHealthSkill.right_leg_health);
+                    break;
 
-                    case "RightLeg":
-                        bodyPart.Health.Maximum = AddHpPerLevel(increment, charType, bodyPart, baseHealth.right_leg_health, increaseHealth.right_leg_health) +
-                            AddHpPerSkillLevel(charType, hpSkillv, bodyPart, increasePerHealthSkill.right_leg_health);
-                        break;
-
-                    default:
-                        _logger.Info($"{bodyPartName} is missing");
-                        break;
-                }
+                default:
+                    _logger.Info($"{bodyPartName} is missing");
+                    break;
+            }
             CheckIfTooMuchHealth(bodyPartName, bodyPart);
             ResetScavHealthOnLoad(bodyPart, baseHealth);
             if (_config.debug)

--- a/HealthPerLevel.cs
+++ b/HealthPerLevel.cs
@@ -345,7 +345,7 @@ namespace HealthPerLevel_cs
 
                 default:
                     _logger.Info($"{bodyPartName} is missing");
-                    break;
+                    return;
             }
             bodyPart.Health.Maximum = Math.Floor(AddHpPerLevel(increment, charType, bodyPart, bodyBaseHp, increasePerLevel) +
                         AddHpPerSkillLevel(charType, hpSkillv, bodyPart, increasePerHpSkill));

--- a/HealthPerLevel.cs
+++ b/HealthPerLevel.cs
@@ -295,47 +295,60 @@ namespace HealthPerLevel_cs
 
             double increment = GetIncrement(accLv, charType);
 
+            float bodyBaseHp = 0f;
+            float increasePerLevel = 0f;
+            float increasePerHpSkill = 0f;
+
             switch (bodyPartName)
             {
                 case "Head":
-                    bodyPart.Health.Maximum = AddHpPerLevel(increment, charType, bodyPart, baseHealth.head_health, increaseHealth.head_health) +
-                        AddHpPerSkillLevel(charType, hpSkillv, bodyPart, increasePerHealthSkill.head_health);
+                    bodyBaseHp = baseHealth.head_health;
+                    increasePerLevel = increaseHealth.head_health;
+                    increasePerHpSkill = increasePerHealthSkill.head_health;
                     break;
 
                 case "Chest":
-                    bodyPart.Health.Maximum = AddHpPerLevel(increment, charType, bodyPart, baseHealth.thorax_health, increaseHealth.thorax_health) +
-                        AddHpPerSkillLevel(charType, hpSkillv, bodyPart, increasePerHealthSkill.thorax_health);
+                    bodyBaseHp = baseHealth.thorax_health;
+                    increasePerLevel = increaseHealth.thorax_health;
+                    increasePerHpSkill = increasePerHealthSkill.thorax_health;
                     break;
 
                 case "Stomach":
-                    bodyPart.Health.Maximum = AddHpPerLevel(increment, charType, bodyPart, baseHealth.stomach_health, increaseHealth.stomach_health) +
-                        AddHpPerSkillLevel(charType, hpSkillv, bodyPart, increasePerHealthSkill.stomach_health);
+                    bodyBaseHp = baseHealth.stomach_health;
+                    increasePerLevel = increaseHealth.stomach_health;
+                    increasePerHpSkill = increasePerHealthSkill.stomach_health;
                     break;
 
                 case "LeftArm":
-                    bodyPart.Health.Maximum = AddHpPerLevel(increment, charType, bodyPart, baseHealth.left_arm_health, increaseHealth.left_arm_health) +
-                        AddHpPerSkillLevel(charType, hpSkillv, bodyPart, increasePerHealthSkill.left_arm_health);
+                    bodyBaseHp = baseHealth.left_arm_health;
+                    increasePerLevel = increaseHealth.left_arm_health;
+                    increasePerHpSkill = increasePerHealthSkill.left_arm_health;
                     break;
 
                 case "LeftLeg":
-                    bodyPart.Health.Maximum = AddHpPerLevel(increment, charType, bodyPart, baseHealth.left_leg_health, increaseHealth.left_leg_health) +
-                        AddHpPerSkillLevel(charType, hpSkillv, bodyPart, increasePerHealthSkill.left_leg_health);
+                    bodyBaseHp = baseHealth.left_leg_health;
+                    increasePerLevel = increaseHealth.left_leg_health;
+                    increasePerHpSkill = increasePerHealthSkill.left_leg_health;
                     break;
 
                 case "RightArm":
-                    bodyPart.Health.Maximum = AddHpPerLevel(increment, charType, bodyPart, baseHealth.right_arm_health, increaseHealth.right_arm_health) +
-                        AddHpPerSkillLevel(charType, hpSkillv, bodyPart, increasePerHealthSkill.right_arm_health);
+                    bodyBaseHp = baseHealth.right_arm_health;
+                    increasePerLevel = increaseHealth.right_arm_health;
+                    increasePerHpSkill = increasePerHealthSkill.right_arm_health;
                     break;
 
                 case "RightLeg":
-                    bodyPart.Health.Maximum = AddHpPerLevel(increment, charType, bodyPart, baseHealth.right_leg_health, increaseHealth.right_leg_health) +
-                        AddHpPerSkillLevel(charType, hpSkillv, bodyPart, increasePerHealthSkill.right_leg_health);
+                    bodyBaseHp = baseHealth.right_leg_health;
+                    increasePerLevel = increaseHealth.right_leg_health;
+                    increasePerHpSkill = increasePerHealthSkill.right_leg_health;
                     break;
 
                 default:
                     _logger.Info($"{bodyPartName} is missing");
                     break;
             }
+            bodyPart.Health.Maximum = Math.Floor(AddHpPerLevel(increment, charType, bodyPart, bodyBaseHp, increasePerLevel) +
+                        AddHpPerSkillLevel(charType, hpSkillv, bodyPart, increasePerHpSkill));
             CheckIfTooMuchHealth(bodyPartName, bodyPart);
             ResetScavHealthOnLoad(bodyPart, baseHealth);
             if (_config.debug)

--- a/Interfaces/IHealth.cs
+++ b/Interfaces/IHealth.cs
@@ -2,12 +2,12 @@
 {
     public interface IHealth
     {
-        public int thorax_health { get; set; }
-        public int stomach_health { get; set; }
-        public int head_health { get; set; }
-        public int left_arm_health { get; set; }
-        public int right_arm_health { get; set; }
-        public int left_leg_health { get; set; }
-        public int right_leg_health { get; set; }
+        public float thorax_health { get; set; }
+        public float stomach_health { get; set; }
+        public float head_health { get; set; }
+        public float left_arm_health { get; set; }
+        public float right_arm_health { get; set; }
+        public float left_leg_health { get; set; }
+        public float right_leg_health { get; set; }
     }
 }

--- a/config/ConfigJson.cs
+++ b/config/ConfigJson.cs
@@ -28,35 +28,35 @@ namespace HealthPerLevel_cs.config
 
     public class Base_Health_PMC : IHealth
     {
-        public int thorax_health { get; set; }
-        public int stomach_health { get; set; }
-        public int head_health { get; set; }
-        public int left_arm_health { get; set; }
-        public int right_arm_health { get; set; }
-        public int left_leg_health { get; set; }
-        public int right_leg_health { get; set; }
+        public float thorax_health { get; set; }
+        public float stomach_health { get; set; }
+        public float head_health { get; set; }
+        public float left_arm_health { get; set; }
+        public float right_arm_health { get; set; }
+        public float left_leg_health { get; set; }
+        public float right_leg_health { get; set; }
     }
 
     public class Increase_Per_Level_PMC : IHealth
     {
-        public int thorax_health { get; set; }
-        public int stomach_health { get; set; }
-        public int head_health { get; set; }
-        public int left_arm_health { get; set; }
-        public int right_arm_health { get; set; }
-        public int left_leg_health { get; set; }
-        public int right_leg_health { get; set; }
+        public float thorax_health { get; set; }
+        public float stomach_health { get; set; }
+        public float head_health { get; set; }
+        public float left_arm_health { get; set; }
+        public float right_arm_health { get; set; }
+        public float left_leg_health { get; set; }
+        public float right_leg_health { get; set; }
     }
 
     public class Increase_Per_Health_Skill_Level_PMC : IHealth
     {
-        public int thorax_health { get; set; }
-        public int stomach_health { get; set; }
-        public int head_health { get; set; }
-        public int left_arm_health { get; set; }
-        public int right_arm_health { get; set; }
-        public int left_leg_health { get; set; }
-        public int right_leg_health { get; set; }
+        public float thorax_health { get; set; }
+        public float stomach_health { get; set; }
+        public float head_health { get; set; }
+        public float left_arm_health { get; set; }
+        public float right_arm_health { get; set; }
+        public float left_leg_health { get; set; }
+        public float right_leg_health { get; set; }
     }
 
     public class SCAV : ICharacter<Base_Health_SCAV, Increase_Per_Level_SCAV, Increase_Per_Health_Skill_Level_SCAV>
@@ -75,35 +75,35 @@ namespace HealthPerLevel_cs.config
 
     public class Base_Health_SCAV : IHealth
     {
-        public int thorax_health { get; set; }
-        public int stomach_health { get; set; }
-        public int head_health { get; set; }
-        public int left_arm_health { get; set; }
-        public int right_arm_health { get; set; }
-        public int left_leg_health { get; set; }
-        public int right_leg_health { get; set; }
+        public float thorax_health { get; set; }
+        public float stomach_health { get; set; }
+        public float head_health { get; set; }
+        public float left_arm_health { get; set; }
+        public float right_arm_health { get; set; }
+        public float left_leg_health { get; set; }
+        public float right_leg_health { get; set; }
     }
 
     public class Increase_Per_Level_SCAV : IHealth
     {
-        public int thorax_health { get; set; }
-        public int stomach_health { get; set; }
-        public int head_health { get; set; }
-        public int left_arm_health { get; set; }
-        public int right_arm_health { get; set; }
-        public int left_leg_health { get; set; }
-        public int right_leg_health { get; set; }
+        public float thorax_health { get; set; }
+        public float stomach_health { get; set; }
+        public float head_health { get; set; }
+        public float left_arm_health { get; set; }
+        public float right_arm_health { get; set; }
+        public float left_leg_health { get; set; }
+        public float right_leg_health { get; set; }
     }
 
     public class Increase_Per_Health_Skill_Level_SCAV : IHealth
     {
-        public int thorax_health { get; set; }
-        public int stomach_health { get; set; }
-        public int head_health { get; set; }
-        public int left_arm_health { get; set; }
-        public int right_arm_health { get; set; }
-        public int left_leg_health { get; set; }
-        public int right_leg_health { get; set; }
+        public float thorax_health { get; set; }
+        public float stomach_health { get; set; }
+        public float head_health { get; set; }
+        public float left_arm_health { get; set; }
+        public float right_arm_health { get; set; }
+        public float left_leg_health { get; set; }
+        public float right_leg_health { get; set; }
     }
 
     public class AI


### PR DESCRIPTION
#### PR Classification
API change and code cleanup to support non-integer health values for body parts.

#### PR Summary
This pull request updates health-related properties and calculations to use float instead of int, enabling more precise health increments per level and skill. The logic for assigning health values is also refactored for clarity and flexibility.
- IHealth.cs and all implementing classes: Change health properties from int to float.
- HealthPerLevel.cs: Refactor body part health assignment logic to use local float variables and update calculation methods to support float values.
